### PR TITLE
Update picoGuild for MoP

### DIFF
--- a/picoGuild.lua
+++ b/picoGuild.lua
@@ -89,9 +89,9 @@ end
 function f:GUILD_ROSTER_UPDATE()
 	if IsInGuild() then
 	local total, online = GetNumGuildMembers()
-		local currentXP, remainingXP, dailyXP, maxDailyXP = UnitGetGuildXP("player")
-		local level, capped = GetGuildLevel() + currentXP/(currentXP + remainingXP), dailyXP == maxDailyXP and "*" or ""
-		dataobj.text = string.format("Lv%.1f%s - %d/%d", math.floor(level*10)/10, capped, online, total)
+		local currentXP, remainingXP = UnitGetGuildXP("player")
+		local level = GetGuildLevel() + currentXP/(currentXP + remainingXP)
+		dataobj.text = string.format("Lv%.1f - %d/%d", math.floor(level*10)/10, online, total)
 	else dataobj.text = L["No Guild"] end
 end
 f.GUILD_XP_UPDATE = f.GUILD_ROSTER_UPDATE
@@ -111,9 +111,8 @@ function dataobj.OnEnter(self)
 	tip:AddLine("picoGuild")
 
 	if IsInGuild() then
-		local currentXP, remainingXP, dailyXP, maxDailyXP = UnitGetGuildXP("player")
+		local currentXP, remainingXP = UnitGetGuildXP("player")
 		local nextLevelXP = currentXP + remainingXP
-		local percentDaily = math.ceil((dailyXP / maxDailyXP) * 100)
 
 		local gender = UnitSex("player")
 		local name, description, standingID, barMin, barMax, barValue = GetGuildFactionInfo()
@@ -124,7 +123,6 @@ function dataobj.OnEnter(self)
 		tip:AddLine(GetGuildRosterMOTD(), 0, 1, 0, true)
 		tip:AddLine(" ")
 
-		tip:AddLine(string.format("Today:|cffffffff %d%% (%s left) - %s |rTNL", percentDaily, TextStatusBar_CapDisplayOfNumericValue(maxDailyXP - dailyXP), TextStatusBar_CapDisplayOfNumericValue(remainingXP)))
 		tip:AddLine(string.format("Rep:|cffffffff %s %d%% (%d/%d)", factionStandingtext, barValue / barMax * 100, barValue, barMax))
 		tip:AddLine(" ")
 


### PR DESCRIPTION
Daily guild XP cap is gone; tweak for that.  There's not actually anything in the code which uses the remaining values currentXP and remainingXP, so those could be removed too; or else something could be added maybe to the tip to indicate those numbers if the guild's not already at max level?
